### PR TITLE
Add full path to theme files

### DIFF
--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -15,9 +15,9 @@
     <![endif]-->
 
     <!-- Le styles -->
-    <link href="{{ ASSET_PATH }}/bootstrap/css/bootstrap.2.2.2.min.css" rel="stylesheet">
-    <link href="{{ ASSET_PATH }}/css/style.css?body=1" rel="stylesheet" type="text/css" media="all">
-    <link href="{{ ASSET_PATH }}/css/kbroman.css" rel="stylesheet" type="text/css" media="all">
+    <link href="https://www.shapirolab.ca/assets/themes/twitter/bootstrap/css/bootstrap.2.2.2.min.css" rel="stylesheet">
+    <link href="https://www.shapirolab.ca/assets/themes/twitter/css/style.css?body=1" rel="stylesheet" type="text/css" media="all">
+    <link href="https://www.shapirolab.ca/assets/themes/twitter/css/kbroman.css" rel="stylesheet" type="text/css" media="all">
 
     <!-- Le fav and touch icons -->
 


### PR DESCRIPTION
Add full path so that 'https' (rather than 'http') can be specified explicitly. I think this should address the issue of the webpage sometimes not loading correctly (this worked for my personal website at least!).